### PR TITLE
Fix snippet manager README typo

### DIFF
--- a/snippet_manager/README.md
+++ b/snippet_manager/README.md
@@ -1,4 +1,4 @@
-# Snipper Manager Plugin for IDA
+# Snippet Manager Plugin for IDA
 
 This plugin for IDA provides a set of functionality for importing, exporting or deleting all snippets from IDA (Shift-F2 window).
 


### PR DESCRIPTION
## Summary
- fix a minor typo in the snippet manager README

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `pytest -q` *(fails: command not found)*